### PR TITLE
Fix issue #6 – NullPointException

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ android:
     - tools
     - tools
     - platform-tools
-    - build-tools-25.0.1
+    - build-tools-25.0.2
     - android-25
     - android-24
     - extra-android-support
@@ -22,7 +22,7 @@ branches:
     - dev
 
 before_install:
-  - gradle :wrapper --configure-on-demand
+  - gradle wrapper -b wrapper.gradle
 
 before_script:
   - echo no | android create avd -f -n test -t android-24 -b armeabi-v7a

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 ![Icon](assets/icon.png) Badger
 ===============================
-[![Build][1]][2] [![Release][3]][4] [![Methods][5]][6] [![Arsenal][7]][8]
+[![Build][1]][2]
+[![Release][3]][4]
+[![Methods][5]][6]
+[![Arsenal][7]][8]
 
 *Badger* is a generalized single purpose library for adding badges to drawables
 in general and menu items in particular.
@@ -153,12 +156,12 @@ License
     limitations under the License.
 
 
+  [sett]: https://en.oxforddictionaries.com/definition/sett
   [1]: https://travis-ci.org/volders/Badger.svg?branch=master
   [2]: https://travis-ci.org/volders/Badger
   [3]: https://jitpack.io/v/berlin.volders/badger.svg
   [4]: https://jitpack.io/#berlin.volders/badger
-  [5]: https://img.shields.io/badge/Methods%20count-110-e91e63.svg
+  [5]: https://img.shields.io/badge/Methods%20count-111-e91e63.svg
   [6]: http://www.methodscount.com/?lib=berlin.volders%3Abadger%3A%2B
-  [7]: https://img.shields.io/badge/Android%20Arsenal-Badger-blue.svg?style=flat
+  [7]: https://img.shields.io/badge/Android%20Arsenal-Badger-blue.svg
   [8]: https://android-arsenal.com/details/1/4794
-  [sett]: https://en.oxforddictionaries.com/definition/sett

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
     }
 }
@@ -16,15 +16,11 @@ allprojects {
 }
 
 ext {
-    androidSupportVersion = '25.0.1'
-    xBuildToolsVersion = '25.0.1'
+    androidSupportVersion = '25.3.1'
+    xBuildToolsVersion = '25.0.2'
     xTargetSdkVersion = 25
 }
 
 task clean(type: Delete) {
     delete rootProject.buildDir
-}
-
-task wrapper(type: Wrapper) {
-    gradleVersion = '3.2'
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -9,7 +9,7 @@ android {
         minSdkVersion 9
         targetSdkVersion xTargetSdkVersion
 
-        versionCode 2
+        versionCode 3
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }

--- a/library/src/androidTest/java/berlin/volders/badger/BadgerTest.java
+++ b/library/src/androidTest/java/berlin/volders/badger/BadgerTest.java
@@ -98,6 +98,15 @@ public class BadgerTest {
         assertBadged(imageView.getDrawable(), badge, drawables);
     }
 
+    @Test
+    public void sett_and_mutate() {
+        Drawable[] drawables = {factory.createBadge(), new TestDrawable()};
+        LayerDrawable layer = new LayerDrawable(drawables);
+        layer.setId(0, R.id.badger_drawable);
+
+        Badger.sett(layer, factory).drawable.mutate();
+    }
+
     void assertBadged(Drawable drawable, TestBadgeDrawable badge, Drawable... drawables) {
         assertThat(drawable, instanceOf(LayerDrawable.class));
         LayerDrawable layer = (LayerDrawable) drawable;

--- a/library/src/androidTest/java/berlin/volders/badger/TestDrawable.java
+++ b/library/src/androidTest/java/berlin/volders/badger/TestDrawable.java
@@ -21,6 +21,7 @@ import android.graphics.ColorFilter;
 import android.graphics.PixelFormat;
 import android.graphics.drawable.Drawable;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 class TestDrawable extends Drawable {
 
@@ -39,5 +40,22 @@ class TestDrawable extends Drawable {
     @Override
     public int getOpacity() {
         return PixelFormat.UNKNOWN;
+    }
+
+    @Nullable
+    @Override
+    public ConstantState getConstantState() {
+        return new ConstantState() {
+            @NonNull
+            @Override
+            public Drawable newDrawable() {
+                return TestDrawable.this;
+            }
+
+            @Override
+            public int getChangingConfigurations() {
+                return 0;
+            }
+        };
     }
 }

--- a/library/src/main/java/berlin/volders/badger/BadgeDrawable.java
+++ b/library/src/main/java/berlin/volders/badger/BadgeDrawable.java
@@ -20,6 +20,7 @@ import android.graphics.ColorFilter;
 import android.graphics.PixelFormat;
 import android.graphics.drawable.Drawable;
 import android.support.annotation.IntRange;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 /**
@@ -83,5 +84,28 @@ public abstract class BadgeDrawable extends Drawable {
      */
     public interface Factory<T extends BadgeDrawable> {
         T createBadge();
+    }
+
+    @Nullable
+    @Override
+    public ConstantState getConstantState() {
+        return new DummyState();
+    }
+
+    private class DummyState extends ConstantState {
+
+        DummyState() {
+        }
+
+        @NonNull
+        @Override
+        public Drawable newDrawable() {
+            return BadgeDrawable.this;
+        }
+
+        @Override
+        public int getChangingConfigurations() {
+            return 0;
+        }
     }
 }

--- a/wrapper.gradle
+++ b/wrapper.gradle
@@ -1,0 +1,3 @@
+task wrapper(type: Wrapper) {
+    gradleVersion = '3.4.1'
+}


### PR DESCRIPTION
Fix issue #6 .
Add dummy `ConstantState` to prevent https://code.google.com/p/android/issues/detail?id=191754

Next step: Make drawables completely mutable.